### PR TITLE
Fix Dependabot langchain alerts: upgrade ollama-rag to langchain 1.x

### DIFF
--- a/RECAPS.md
+++ b/RECAPS.md
@@ -1,0 +1,13 @@
+# Recaps
+
+Session-by-session log of completed work, newest first.
+
+## 2026-06-23
+
+### Fix Dependabot langchain alerts in ollama-rag demos
+
+- Resolved all 6 open Dependabot alerts (langchain `<= 1.3.8` path-traversal / sandbox-escape, medium) by upgrading langchain to `>=1.3.9,<2.0.0` across both copies of the `ollama-rag` demo (`serverless/cloud-run-gpu/ollama-rag` and `serverless/cloud-run/cr-gpu/ollama-rag`, which are byte-identical).
+- The fix required a langchain 0.3 → 1.x major bump (no 0.3.x patch exists). Companion pins bumped for core 1.x compatibility: `langchain-community>=0.4.0`, `langchain-google-vertexai>=3.0.0`, `langchain-google-community>=5.0.0`, `langchain-google-alloydb-pg>=0.15.0`, `langserve>=0.3.3` (0.3.3 relaxed its core cap to `<2`).
+- Code ports: streamlit `app.py` moved `langchain.llms.Ollama` → `langchain_ollama.OllamaLLM` (added `langchain-ollama` dep, dropped unused `langchain-community`/`langchain-google-community` + two unused imports); indexer `indexer.py` dropped the unused `langchain.llms.Ollama` import and **kept** `langchain_community.vectorstores.pgvector.PGVector` (still ships in community 0.4.2) to preserve the pg8000 AlloyDB connector — `langchain-postgres` was rejected because it hard-requires psycopg3/asyncpg.
+- Verified all three requirement sets resolve in a clean venv (langchain 1.3.11 / core 1.4.8 / community 0.4.2) and all four Python files compile.
+- Open follow-ups: the two ollama-rag trees are exact duplicates (worth de-duping); root `requirements.txt` still carries langchain/streamlit/fastapi/langserve that `__main__.py` (pure Pulumi) never imports; `VertexAIEmbeddings(model_name="textembedding-gecko@003")` uses a Google-retired embedding model — runtime-untested here.

--- a/serverless/cloud-run-gpu/ollama-rag/apps/indexer/indexer.py
+++ b/serverless/cloud-run-gpu/ollama-rag/apps/indexer/indexer.py
@@ -2,7 +2,6 @@ import os
 from google.cloud.alloydb.connector import Connector
 from google.cloud import storage
 import pg8000
-from langchain.llms import Ollama
 from langchain_community.vectorstores.pgvector import PGVector
 from langchain_google_vertexai import VertexAIEmbeddings
 import pymupdf

--- a/serverless/cloud-run-gpu/ollama-rag/apps/indexer/requirements.txt
+++ b/serverless/cloud-run-gpu/ollama-rag/apps/indexer/requirements.txt
@@ -1,11 +1,11 @@
 google-cloud-alloydb>=0.4.0,<1.0.0
-langchain-google-vertexai>=2.0.9,<3.0.0
-langchain>=0.3.11,<1.0.0
-langchain-community>=0.3.11,<1.0.0
+langchain-google-vertexai>=3.0.0,<4.0.0
+langchain>=1.3.9,<2.0.0
+langchain-community>=0.4.0,<1.0.0
 pgvector>=0.3.6,<1.0.0
 google-cloud-alloydb-connector[pg8000]>=1.6.0,<2.0.0
 cloud-sql-python-connector>=1.15.0,<2.0.0
-langchain-google-alloydb-pg>=0.8.0,<1.0.0
+langchain-google-alloydb-pg>=0.15.0,<1.0.0
 SQLAlchemy>=2.0.36,<2.1.0
 google-cloud-storage>=2.19.0,<3.0.0rc1
 PyMuPDF>=1.25.1,<1.50.0

--- a/serverless/cloud-run-gpu/ollama-rag/apps/streamlit/app.py
+++ b/serverless/cloud-run-gpu/ollama-rag/apps/streamlit/app.py
@@ -1,14 +1,12 @@
 import os
 from typing import List
 from fastapi import FastAPI
-from langchain.llms import Ollama
-from langchain.output_parsers import CommaSeparatedListOutputParser
-from langchain.prompts import PromptTemplate
+from langchain_ollama import OllamaLLM
 import streamlit
 
 ollama_url = os.environ["OLLAMA_BASE_URL"]
 
-llm = Ollama(model="gemma2:2b", base_url=ollama_url, verbose=True)
+llm = OllamaLLM(model="gemma2:2b", base_url=ollama_url, verbose=True)
 
 def sendPrompt(prompt):
     global llm

--- a/serverless/cloud-run-gpu/ollama-rag/apps/streamlit/requirements.txt
+++ b/serverless/cloud-run-gpu/ollama-rag/apps/streamlit/requirements.txt
@@ -1,5 +1,4 @@
-langchain>=0.3.4,<1.0.0
-langchain-community>=0.3.3,<1.0.0
-langchain-google-community==2.0.1
+langchain>=1.3.9,<2.0.0
+langchain-ollama>=1.0.0,<2.0.0
 streamlit>=1.41.0,<2.0.0
 fastapi>=0.115.6,<1.0.0

--- a/serverless/cloud-run-gpu/ollama-rag/requirements.txt
+++ b/serverless/cloud-run-gpu/ollama-rag/requirements.txt
@@ -4,10 +4,10 @@ pulumi-docker>=4.5.6,<5.0.0
 pulumi-docker-build>=0.0.6,<0.1.0
 pulumi-esc-sdk>=0.10.0,<1.0.0
 pulumi-random==4.16.6
-langchain>=0.3.4,<1.0.0
-langchain-community>=0.3.3,<1.0.0
-langchain-google-community==2.0.1
-langserve>=0.3.0,<0.5.0
+langchain>=1.3.9,<2.0.0
+langchain-community>=0.4.0,<1.0.0
+langchain-google-community>=5.0.0,<6.0.0
+langserve>=0.3.3,<0.4.0
 streamlit>=1.41.0,<2.0.0
 fastapi>=0.115.6,<1.0.0
 uvicorn>=0.32.0

--- a/serverless/cloud-run/cr-gpu/ollama-rag/apps/indexer/indexer.py
+++ b/serverless/cloud-run/cr-gpu/ollama-rag/apps/indexer/indexer.py
@@ -2,7 +2,6 @@ import os
 from google.cloud.alloydb.connector import Connector
 from google.cloud import storage
 import pg8000
-from langchain.llms import Ollama
 from langchain_community.vectorstores.pgvector import PGVector
 from langchain_google_vertexai import VertexAIEmbeddings
 import pymupdf

--- a/serverless/cloud-run/cr-gpu/ollama-rag/apps/indexer/requirements.txt
+++ b/serverless/cloud-run/cr-gpu/ollama-rag/apps/indexer/requirements.txt
@@ -1,11 +1,11 @@
 google-cloud-alloydb>=0.4.0,<1.0.0
-langchain-google-vertexai>=2.0.9,<3.0.0
-langchain>=0.3.11,<1.0.0
-langchain-community>=0.3.11,<1.0.0
+langchain-google-vertexai>=3.0.0,<4.0.0
+langchain>=1.3.9,<2.0.0
+langchain-community>=0.4.0,<1.0.0
 pgvector>=0.3.6,<1.0.0
 google-cloud-alloydb-connector[pg8000]>=1.6.0,<2.0.0
 cloud-sql-python-connector>=1.15.0,<2.0.0
-langchain-google-alloydb-pg>=0.8.0,<1.0.0
+langchain-google-alloydb-pg>=0.15.0,<1.0.0
 SQLAlchemy>=2.0.36,<2.1.0
 google-cloud-storage>=2.19.0,<3.0.0rc1
 PyMuPDF>=1.25.1,<1.50.0

--- a/serverless/cloud-run/cr-gpu/ollama-rag/apps/streamlit/app.py
+++ b/serverless/cloud-run/cr-gpu/ollama-rag/apps/streamlit/app.py
@@ -1,14 +1,12 @@
 import os
 from typing import List
 from fastapi import FastAPI
-from langchain.llms import Ollama
-from langchain.output_parsers import CommaSeparatedListOutputParser
-from langchain.prompts import PromptTemplate
+from langchain_ollama import OllamaLLM
 import streamlit
 
 ollama_url = os.environ["OLLAMA_BASE_URL"]
 
-llm = Ollama(model="gemma2:2b", base_url=ollama_url, verbose=True)
+llm = OllamaLLM(model="gemma2:2b", base_url=ollama_url, verbose=True)
 
 def sendPrompt(prompt):
     global llm

--- a/serverless/cloud-run/cr-gpu/ollama-rag/apps/streamlit/requirements.txt
+++ b/serverless/cloud-run/cr-gpu/ollama-rag/apps/streamlit/requirements.txt
@@ -1,5 +1,4 @@
-langchain>=0.3.4,<1.0.0
-langchain-community>=0.3.3,<1.0.0
-langchain-google-community==2.0.1
+langchain>=1.3.9,<2.0.0
+langchain-ollama>=1.0.0,<2.0.0
 streamlit>=1.41.0,<2.0.0
 fastapi>=0.115.6,<1.0.0

--- a/serverless/cloud-run/cr-gpu/ollama-rag/requirements.txt
+++ b/serverless/cloud-run/cr-gpu/ollama-rag/requirements.txt
@@ -4,10 +4,10 @@ pulumi-docker>=4.5.6,<5.0.0
 pulumi-docker-build>=0.0.6,<0.1.0
 pulumi-esc-sdk>=0.10.0,<1.0.0
 pulumi-random==4.16.6
-langchain>=0.3.4,<1.0.0
-langchain-community>=0.3.3,<1.0.0
-langchain-google-community==2.0.1
-langserve>=0.3.0,<0.5.0
+langchain>=1.3.9,<2.0.0
+langchain-community>=0.4.0,<1.0.0
+langchain-google-community>=5.0.0,<6.0.0
+langserve>=0.3.3,<0.4.0
 streamlit>=1.41.0,<2.0.0
 fastapi>=0.115.6,<1.0.0
 uvicorn>=0.32.0


### PR DESCRIPTION
## What & why

Clears all **6 open Dependabot alerts** — every one is the same advisory: `langchain <= 1.3.8` (path traversal / sandbox escape in file-search middleware & loaders, medium). They appear across the **two byte-identical copies** of the ollama-rag demo (`serverless/cloud-run-gpu/ollama-rag` and `serverless/cloud-run/cr-gpu/ollama-rag`), each with 3 requirements files (root + indexer + streamlit).

The only patched version, `1.3.9`, lives in the **1.x line**, but every file capped langchain at `<1.0.0` — so there's no in-range fix. Remediation required a langchain **0.3 → 1.x major upgrade**, which removed the `langchain.llms` import path the code used.

## Requirements changes (both trees)

| pin | before | after |
|---|---|---|
| langchain | `>=0.3.4,<1.0.0` | `>=1.3.9,<2.0.0` |
| langchain-community | `>=0.3.3,<1.0.0` | `>=0.4.0,<1.0.0` |
| langchain-google-vertexai | `>=2.0.9,<3.0.0` | `>=3.0.0,<4.0.0` |
| langchain-google-community | `==2.0.1` | `>=5.0.0,<6.0.0` |
| langchain-google-alloydb-pg | `>=0.8.0,<1.0.0` | `>=0.15.0,<1.0.0` |
| langserve | `>=0.3.0,<0.5.0` | `>=0.3.3,<0.4.0` |

`langserve 0.3.3` relaxed its `langchain-core` cap to `<2`, so it coexists with langchain 1.x (it's unused in code anyway).

## Code ports

- **streamlit `app.py`**: `langchain.llms.Ollama` → `langchain_ollama.OllamaLLM` (added `langchain-ollama`, dropped the now-unused `langchain-community` / `langchain-google-community`); also removed two imports that were never used (`CommaSeparatedListOutputParser`, `PromptTemplate`).
- **`indexer.py`**: dropped the unused `langchain.llms.Ollama` import; **kept** `langchain_community.vectorstores.pgvector.PGVector` (still ships in community 0.4.2) to preserve the **pg8000 AlloyDB connector**. Deliberately did *not* switch to `langchain-postgres` — it hard-requires psycopg3/asyncpg and would force a much larger rewrite of the connector path.

## Verification

- All three requirement sets resolve in a clean venv (resolves to langchain 1.3.11 / langchain-core 1.4.8 / langchain-community 0.4.2).
- All four `.py` files compile (`py_compile`).
- ⚠️ **Not runtime-tested** — the containers need GPU + AlloyDB. Verified at dependency-resolution and compile level only.

## Reviewer notes / out of scope

- The two ollama-rag trees are exact duplicates — worth de-duping in a follow-up.
- Root `requirements.txt` still lists langchain/streamlit/fastapi/langserve that the pure-Pulumi `__main__.py` never imports (bumped to clear the alert, not removed).
- `indexer.py` uses `VertexAIEmbeddings(model_name="textembedding-gecko@003")`, a Google-retired embedding model — unrelated to this CVE but will fail at runtime eventually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
